### PR TITLE
Bump version of NPM to 2.5.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
     'npm-install',
     'npm-install:q',
     'npm-install:lodash:async',
-    'chdir:' + process.cwd(),
+    'chdir:' + process.cwd().replace(/[A-Za-z]:\\/, '/'), // Windows friendly
     'nodeunit'
   ]);
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ grunt.registerTask('default', ['npm-install:lodash:async']);
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
+### v0.1.2
+Updated NPM dependency to version ^2.5.1.
+
 ### v0.1.1
 Updated NPM dependency to version ~1.4.3.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-npm-install",
   "description": "Grunt task to install npm modules.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/iclanzan/grunt-npm-install",
   "author": {
     "name": "Sorin Iclanzan",
@@ -29,12 +29,12 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "npm": "~1.4.3"
+    "npm": "^2.5.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-nodeunit": "^0.4.1",
     "grunt": "~0.4.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumps npm to ^2.5.1 (for local path support in package.json from v2.0.0) and grunt-contrib-nodeunit to ^0.4.1 (to remove dependency on deprecated evals for newer versions of node). Also makes the chdir argument Windows path friendly (I know, yuk). Closes #5.