### PR TITLE
Updated dependencies to allow newer grunt version and remove deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
     "npm": "^3.7.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-nodeunit": "^0.4.1"
+    "grunt": ">=0.4.1",
+    "grunt-cli": ">=0.1.13",
+    "grunt-contrib-clean": ">=0.4.0",
+    "grunt-contrib-jshint": ">=0.1.1",
+    "grunt-contrib-nodeunit": ">=0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.1"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Grunt was throwing deprecation warnings. Updated package versions to fix issues. Tests still pass.
